### PR TITLE
Stick to MySQL only in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ sudo: false
 env:
   matrix:
     - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
-    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
-    - DB=sqlite db_dsn='sqlite:///:memory:'
   global:
     - DEFAULT=1
 
@@ -19,12 +17,11 @@ matrix:
   fast_finish: true
 
 install:
-  - composer install 
+  - composer install
   - mkdir -p build/logs
 
 before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
 
 script:
   - vendor/bin/phpunit


### PR DESCRIPTION
We have seen a variety of issues with PostgreSQL tests
failing, outside of our control.  This is probably because
of us misconfiguring the versions or something.

For now, removing both PostgreSQL and SQLite, since we only
work with MySQL.  These should be re-added at a later stage.