### PR TITLE
SticklerCI configuration adjustment (task #2960)

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -2,3 +2,5 @@ linters:
   phpcs:
     standard: CakePHP
     extensions: '.php,.ctp'
+files:
+  ignore: ['config/*', 'tests/*']


### PR DESCRIPTION
Added `config/` and `tests/` folders to ignore.