### PR TITLE
Code Climate rating calculation for `src/` (task #4302)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,4 +9,6 @@ engines:
 exclude_paths:
 - config/
 - tests/
-
+ratings:
+  paths:
+  - "src/**/*"


### PR DESCRIPTION
Code Climate ratings/grades provide a quick way to measure the
quality of code in file, folder, and overall repository.  Since
we have plenty of irrelevant, third-party, dummy test, and other
unpredictable files, it only makes sense to enable this for the
main `src/` folder.

Here's the link for more information:

  https://docs.codeclimate.com/v1.0/docs/ratings