### PR TITLE
Excluding webroot js and config dirs

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,0 +1,6 @@
+exclude:
+- /config/.*
+- /webroot/js/.*
+languages:
+- javascript
+- php


### PR DESCRIPTION
According to analysis-configuration tool (from bettercodehub), that's how we should exclude js and config dirs from the check. Tests dir is not excluded, as it's automagically identified as test environment, and not scanned against the main code.