### PR TITLE
Removed webroot/plugins/ from CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,6 +9,7 @@ engines:
 exclude_paths:
 - config/
 - tests/
+- webroot/plugins/
 ratings:
   paths:
   - "src/**/*"


### PR DESCRIPTION
The `webroot/plugins` folder contains third-party code, which we
don't need to be notified about by CodeClimate.