### PR TITLE
Add tmp folder to gitignore (task #11084)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 ##########################
 build/
 vendor/
+tmp/
 cghooks.lock
 
 composer.lock


### PR DESCRIPTION
Add `tmp/` folder to `.gitignore` . All child plugins will inherit the fix once updated.