### PR TITLE
Prevent deprecation exceptions in PHPUnit (task #11968)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
     stopOnFailure="false"
     bootstrap="./tests/bootstrap.php"
     verbose="true"
+    convertDeprecationsToExceptions="false"
     >
     <php>
         <ini name="memory_limit" value="-1"/>


### PR DESCRIPTION
This attribute configures whether E_DEPRECATED and E_USER_DEPRECATED events triggered by the code under test are converted to an exception (and mark the test as error).