### PR TITLE
Report debugging methods as forbidden (task #13569)

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,6 +12,11 @@
     <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP">
         <exclude name="Generic.Commenting.Todo" />
     </rule>
+    <rule ref="Generic.PHP.ForbiddenFunctions">
+        <properties>
+            <property name="forbiddenFunctions" type="array" value="debug=>null,dd=>null,var_dump=>null,sizeof=>count,delete=>unset"/>
+        </properties>
+    </rule>
 
     <!-- Do not fail on warnings -->
     <config name="ignore_warnings_on_exit" value="1" />


### PR DESCRIPTION
PHPCS ForbiddenFunctions Sniff is configured to report var_dump, debug and dd as forbidden functions.